### PR TITLE
Find command update

### DIFF
--- a/src/main/java/seedu/medmoriser/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/medmoriser/logic/commands/FindCommand.java
@@ -47,7 +47,6 @@ public class FindCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-
         if (QuizCommand.getIsQuiz()) {
             throw new CommandException(Messages.MESSAGE_ONGOING_QUIZ);
         } else {

--- a/src/main/java/seedu/medmoriser/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/medmoriser/logic/parser/FindCommandParser.java
@@ -29,24 +29,23 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] keywordsArray = trimmedArgs.split("/|, ");;
+        String[] keywordsArray = trimmedArgs.split("/|, ");
+        String[] excludeType = keywordsArray;
 
-        if (keywordsArray[0].contains(" ")) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-        }
         //trim whitespaces
         keywordsArray = trimArg(keywordsArray);
 
         String findType = keywordsArray[0];
-
+        if (keywordsArray.length > 1) {
+            excludeType = Arrays.copyOfRange(keywordsArray, 1, keywordsArray.length);
+        }
         switch (findType) {
         case "t":
-            return new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList(keywordsArray)));
+            return new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList(excludeType)));
         case "q":
-            return new FindCommand(new QuestionContainsKeywordsPredicate(Arrays.asList(keywordsArray)));
+            return new FindCommand(new QuestionContainsKeywordsPredicate(Arrays.asList(excludeType)));
         case "a":
-            return new FindCommand(new AnswerContainsKeywordsPredicate(Arrays.asList(keywordsArray)));
+            return new FindCommand(new AnswerContainsKeywordsPredicate(Arrays.asList(excludeType)));
         default:
             return new FindCommand(new QAndAContainsKeywordsPredicate(Arrays.asList(keywordsArray)));
         }

--- a/src/main/java/seedu/medmoriser/model/qanda/AnswerContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/medmoriser/model/qanda/AnswerContainsKeywordsPredicate.java
@@ -16,10 +16,7 @@ public class AnswerContainsKeywordsPredicate implements Predicate<QAndA> {
     @Override
     public boolean test(QAndA qAndA) {
         return keywords.stream()
-                .anyMatch(keyword -> {
-                    System.out.println("current keyword is: " + keyword);
-                    return qAndA.getAnswer().answer.toLowerCase().contains(keyword.toLowerCase());
-                });
+                .anyMatch(keyword -> qAndA.getAnswer().answer.toLowerCase().contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/seedu/medmoriser/model/qanda/AnswerContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/medmoriser/model/qanda/AnswerContainsKeywordsPredicate.java
@@ -3,8 +3,6 @@ package seedu.medmoriser.model.qanda;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.medmoriser.commons.util.StringUtil;
-
 /**
  * Tests that a {@code QAndA}'s {@code Answer} matches any of the keywords given.
  */
@@ -18,7 +16,10 @@ public class AnswerContainsKeywordsPredicate implements Predicate<QAndA> {
     @Override
     public boolean test(QAndA qAndA) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(qAndA.getAnswer().answer, keyword));
+                .anyMatch(keyword -> {
+                    System.out.println("current keyword is: " + keyword);
+                    return qAndA.getAnswer().answer.toLowerCase().contains(keyword.toLowerCase());
+                });
     }
 
     @Override

--- a/src/main/java/seedu/medmoriser/model/qanda/QuestionContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/medmoriser/model/qanda/QuestionContainsKeywordsPredicate.java
@@ -16,9 +16,7 @@ public class QuestionContainsKeywordsPredicate implements Predicate<QAndA> {
     @Override
     public boolean test(QAndA qAndA) {
         return keywords.stream()
-                .anyMatch(keyword -> {
-                    return qAndA.getQuestion().question.toLowerCase().contains(keyword.toLowerCase());
-                });
+                .anyMatch(keyword -> qAndA.getQuestion().question.toLowerCase().contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/test/java/seedu/medmoriser/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/medmoriser/logic/parser/FindCommandParserTest.java
@@ -49,7 +49,8 @@ public class FindCommandParserTest {
     public void parse_validArgsQuestionContainsKeywordsPredicate_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new QuestionContainsKeywordsPredicate(Arrays.asList("Diabetic Condition", "glucose level")));
+                new FindCommand(new QuestionContainsKeywordsPredicate(Arrays.asList("Diabetic Condition",
+                        "glucose level")));
         assertParseSuccess(parser, "q/Diabetic Condition, glucose level", expectedFindCommand);
 
         // multiple whitespaces between keywords

--- a/src/test/java/seedu/medmoriser/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/medmoriser/logic/parser/FindCommandParserTest.java
@@ -38,33 +38,33 @@ public class FindCommandParserTest {
     public void parse_validArgsAnswerContainsKeywordsPredicate_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new AnswerContainsKeywordsPredicate(Arrays.asList("a", "Alice", "Bob")));
-        assertParseSuccess(parser, "a/Alice, Bob", expectedFindCommand);
+                new FindCommand(new AnswerContainsKeywordsPredicate(Arrays.asList("Chronic Diseases", "Immune")));
+        assertParseSuccess(parser, "a/Chronic Diseases, Immune", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, "a/ \n Alice, \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, "a/ \n Chronic Diseases, \n \t Immune  \t", expectedFindCommand);
     }
 
     @Test
     public void parse_validArgsQuestionContainsKeywordsPredicate_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new QuestionContainsKeywordsPredicate(Arrays.asList("q", "Alice", "Bob")));
-        assertParseSuccess(parser, "q/Alice, Bob", expectedFindCommand);
+                new FindCommand(new QuestionContainsKeywordsPredicate(Arrays.asList("Diabetic Condition", "glucose level")));
+        assertParseSuccess(parser, "q/Diabetic Condition, glucose level", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, "q/ Alice,  Bob  ", expectedFindCommand);
+        assertParseSuccess(parser, "q/ Diabetic Condition ,  glucose level  ", expectedFindCommand);
     }
 
     @Test
     public void parse_validArgsTagContainsKeywordsPredicate_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList("t", "Alice", "Bob")));
-        assertParseSuccess(parser, "t/Alice, Bob", expectedFindCommand);
+                new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList("Immunology", "Chronic Diseases")));
+        assertParseSuccess(parser, "t/Immunology, Chronic Diseases", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, "t/ \n Alice, \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, "t/ \n Immunology, \n \t Chronic Diseases  \t", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/medmoriser/logic/parser/QuizCommandParserTest.java
+++ b/src/test/java/seedu/medmoriser/logic/parser/QuizCommandParserTest.java
@@ -28,7 +28,6 @@ public class QuizCommandParserTest {
         // no leading and trailing whitespaces
         QuizCommand expectedQuizCommand =
                 new QuizCommand(new QAndAContainsKeywordsPredicate(Arrays.asList("digestive", "skeletal")));
-        System.out.println(expectedQuizCommand);
         assertParseSuccess(parser, "digestive, skeletal", expectedQuizCommand);
 
         // multiple whitespaces between keywords


### PR DESCRIPTION
Context:
Q1: What is diabetes?
Tag: Chronic Diseases, Immunology
A1: Body unable to regulate blood sugar level

Q2: asdas
Tag: Nervous System, Immunology
A2: help

Q3: hehe
Tag: Immune System
A3: helpppppp

**What needed fixing**
find a/help
expected: return question 2 & 3
actual: returned all 3 questions

Why: Turns out, parser split a/help -> [a, help], and checked each answer to see if it contains "a" (resulted in Q1 being added). 

Fixed: Parsed only the [help] into the predicates. Changes also made for find q/ and find t/.

close #76 